### PR TITLE
Changes in preparation for hosting the CemConnector API in the OHDSI cloud

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Imports:
     httr,
     magrittr,
     dplyr,
-    shinycssloaders
+    shinycssloaders,
+    yaml
 Suggests:
     testthat,
     devtools,
@@ -38,3 +39,4 @@ License: Apache License 2.0
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM rstudio/plumber
 
 ARG PLUMBER_PORT=8080
+
 # create the application folder
 RUN mkdir -p ~/application
+
 # Install java and rJava
 RUN apt-get -y update && apt-get install -y \
    default-jdk \
@@ -10,11 +12,35 @@ RUN apt-get -y update && apt-get install -y \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/
 
+# install R package dependencies
+RUN R -e "install.packages( \
+c( \
+'devtools', \
+'DatabaseConnector', \
+'checkmate', \
+'R6', \
+'base64enc', \ 
+'jquerylib', \
+'sass', \
+'bslib', \
+'sourcetools', \
+'htmltools', \
+'xtable', \
+'shiny', \
+'tidyselect', \
+'generics', \
+'shinycssloaders', \
+'dplyr', \
+'pool', \
+'shinydashboard' \
+) \
+) "
+
 # copy everything from the current directory into the container
 COPY "/" "application/"
 WORKDIR "application/"
 
-RUN R -e "install.packages('devtools')"
+# install the cemconnector R package
 RUN R -e "devtools::install()"
 
 EXPOSE $PLUMBER_PORT

--- a/R/API.R
+++ b/R/API.R
@@ -42,8 +42,10 @@ loadApi <- function(connectionDetails,
                                                 sourceSchema = sourceSchema,
                                                 usePooledConnection = getOption("CemConnector.UsePooledConnection", TRUE))
 
-
   plumb <- plumber::pr(pathToPlumberApi, envir = envir)
+  customOasSpecification <- yaml::read_yaml(system.file(file.path("api", "cemconnector_openapi.yaml"), package = "CemConnector"))
+  plumb <- plumber::pr_set_api_spec(plumb, customOasSpecification)
+  
   plumb <- plumber::pr_hook(plumb, "exit", function() {
     # Close down database connections
     envir$cemBackendApi$finalize()

--- a/R/Backend.R
+++ b/R/Backend.R
@@ -229,7 +229,9 @@ CemDatabaseBackend <- R6::R6Class(
     #' Get CEM source info as a dataframe
     #' @returns data.frame of sources
     getCemSourceInfo = function() {
-      return(self$connection$queryDb("SELECT * FROM @schema.source", schema = self$sourceSchema))
+      return(self$connection$queryDb("SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} * FROM (SELECT * FROM @schema.source) results;", 
+				     limit_row_count = Sys.getenv("LIMIT_ROW_COUNT"),
+				     schema = self$sourceSchema))
     },
 
     #' @description
@@ -290,3 +292,4 @@ CemDatabaseBackend <- R6::R6Class(
     }
   )
 )
+

--- a/R/DatabaseConnections.R
+++ b/R/DatabaseConnections.R
@@ -29,7 +29,7 @@ ConnectionHandler <- R6::R6Class(
     },
 
     renderTranslateSql = function(query, ...) {
-      sql <- SqlRender::render(sql = query, ...)
+      sql <- SqlRender::render(sql = query, limit_row_count = Sys.getenv("LIMIT_ROW_COUNT"), ...)
       SqlRender::translate(sql, targetDialect = self$connectionDetails$dbms)
     },
 
@@ -67,6 +67,7 @@ ConnectionHandler <- R6::R6Class(
         if (self$connectionDetails$dbms %in% c("postgresql", "redshift")) {
           DatabaseConnector::dbExecute(self$con, "ABORT;")
         }
+        print(sql)
         stop(error)
       })
 

--- a/inst/api/cemconnector_openapi.yaml
+++ b/inst/api/cemconnector_openapi.yaml
@@ -1,0 +1,350 @@
+servers:
+  - url: '/'
+openapi: 3.0.3
+info:
+  description: This is the OHDSI CemConnector API for the OHDSI Common Evidence Database (CEM). This API is still under development.
+  title: OHDSI CemConnector API
+  license:
+    name: "Apache 2.0"
+    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+  version: 1.0.0
+components:
+  schemas:
+    Status:
+      type: object
+      properties:
+        status:
+          type: string
+    Version:
+      type: object
+      properties:
+        version:
+          type: string
+    Source:
+      type: object
+      properties:
+        sourceId:
+          type: string
+        description:
+          type: string
+        provenance:
+          type: string
+        contributorOrganization:
+          type: string
+        contactName:
+          type: string
+        creationDate:
+          type: string
+        coverageStartDate:
+          type: string
+        coverageEndDate:
+          type: string
+        versionIdentifier:
+          type: string
+    SourceArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/Source"
+    ConceptId:
+      type: object
+      properties:
+        conceptId:
+          type:
+            number
+    ConceptIdArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/ConceptId"
+    Concept:
+      type: object
+      properties:
+        conceptId:
+          type: number
+        conceptName:
+          type: string
+    ConceptArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/Concept"
+    IngredientEvidenceSummary:
+      type: object
+      properties:
+        ingredientConceptId:
+          type: number
+        conceptName:
+          type: string
+        evidenceExists:
+          type: number
+    IngredientEvidenceSummaryArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/IngredientEvidenceSummary"
+    ConditionEvidenceSummary:
+      type: object
+      properties:
+        conditionConceptId:
+          type: number
+        conceptName:
+          type: string
+        evidenceExists:
+          type: number
+    ConditionEvidenceSummaryArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/ConditionEvidenceSummary"
+    Evidence:
+      type: object
+      properties:
+        conceptName1:
+          type: string
+        conceptName2:
+          type: string
+        conceptId1:
+          type: number
+        sourceCode1:
+          type: string
+        sourceCodeType1:
+          type: string
+        conceptId2:
+          type: number
+        sourceCode2:
+          type: string
+        sourceCodeType2:
+          type: string
+        sourceId:
+          type: string
+        evidenceType:
+          type: string
+        relationshipId:
+          type: string
+        statisticValue:
+          type: number
+        statisticValueType:
+          type: string
+        uniqueIdentifier:
+          type: string
+        uniqueIdentifierType:
+          type: string
+        countHow:
+          type: string
+    EvidenceArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/Evidence"
+paths:
+  /:
+    get:
+      summary: ' Get API status'
+      responses:
+        default:
+          description: Service status string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+      parameters: []
+  /version:
+    get:
+      summary: ' Get CemConnector API version'
+      responses:
+        default:
+          description: Service version string.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Version'
+      parameters: []
+  /cemSourceInfo:
+    get:
+      summary: ' Get Evidence sources'
+      parameters: []
+      responses:
+        default:
+          description: Evidence sources array.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SourceArray'
+  /conditionEvidenceSummary:
+    post:
+      summary: ' For a set of OMOP vocabulary standard condition concepts get the evidence summary of associated ingredients'
+      parameters: []
+      requestBody:
+        content:
+            application/json:
+              schema:
+                properties:
+                  conditionConceptSet:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConceptIdArray"
+                    description: >-
+                      conceptset of conditions. Must be an array of concept ids and
+                      use only OMOP standard concepts
+                  siblingLookupLevels:
+                    type: number
+                    description: number of sibling levels to look up to find matches
+      responses:
+        default:
+          description: Ingredients evidence summary array.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IngredientEvidenceSummaryArray'
+  /conditionEvidence:
+    post:
+      summary: ' For a set of OMOP standard vocabulary condition concepts get the evidence for associated ingredients'
+      parameters: []
+      requestBody:
+        content:
+            application/json:
+              schema:
+                properties:
+                  conditionConceptSet:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConceptIdArray"
+                    description: >-
+                      conceptset of conditions. Must be an array of concept ids and
+                      use only OMOP standard concepts
+                  siblingLookupLevels:
+                    type: number
+                    description: number of sibling levels to look up to find matches - default is zero
+      responses:
+        default:
+          description: Evidence array.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvidenceArray'
+  /ingredientEvidenceSummary:
+    post:
+      summary: ' For a set of OMOP vocabulary standard ingredient concepts get the evidence summary for associated conditions'
+      parameters: []
+      requestBody:
+        content:
+            application/json:
+              schema:
+                properties:
+                  ingredientConceptSet:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConceptIdArray"
+                    description: >-
+                      conceptset of drug ingredients. Must be an array of concept ids and
+                      use only OMOP standard concepts
+      responses:
+        default:
+          description: Conditions evidence summary array.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConditionEvidenceSummaryArray'
+  /ingredientEvidence:
+    post:
+      summary: ' For a set of OMOP standard vocabulary ingredients concepts get the evidence for associated conditions'
+      parameters: []
+      requestBody:
+        content:
+            application/json:
+              schema:
+                properties:
+                  ingredientConceptSet:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConceptIdArray"
+                    description: >-
+                      conceptset of drug ingredients. Must be an array of concept ids and
+                      use only OMOP standard concepts
+      responses:
+        default:
+          description: Evidence array.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvidenceArray'
+  /relationships:
+    post:
+      summary: ' For a set of OMOP standard vocabulary ingredient and drug concepts get the evidence of relationships'
+      parameters: []
+      requestBody:
+        content:
+            application/json:
+              schema:
+                properties:
+                  ingredientConceptSet:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConceptIdArray"
+                    description: >-
+                      conceptset of drug ingredients. Must be an array of concept ids and
+                      use only OMOP standard concepts
+                  conditionConceptSet:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConceptIdArray"
+                    description: >-
+                      conceptset of conditions. Must be an array of concept ids and
+                      use only OMOP standard concepts
+                  conditionSiblingLookupLevels:
+                    type: number
+                    description: number of levels to lookup condition siblings in the concept ancestry - default is 0
+      responses:
+        default:
+          description: Evidence array.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvidenceArray'
+  /suggestedControlConditions:
+    post:
+      summary: ' For a given ingredient concept set get suggested negative controls conditions. These are based on condition concepts with a lack of evidence available and ranked by occurence across the ohdsi network.'
+      parameters: []
+      requestBody:
+        content:
+            application/json:
+              schema:
+                properties:
+                  ingredientConceptSet:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConceptIdArray"
+                    description: >-
+                      conceptset of drug ingredients. Must be an array of concept ids and
+                      use only OMOP standard concepts 
+                  nControls:
+                    type: number
+                    description: number of control concepts to suggest
+      responses:
+        default:
+          description: Negative controls condition concepts array.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConceptArray'
+  /suggestedControlIngredients:
+    post:
+      summary: ' For a given condition concept set get suggested negative controls ingredients. These are based on condition concepts with a lack of evidence available and ranked by occurence across the ohdsi network.'
+      parameters: []
+      requestBody:
+        content:
+            application/json:
+              schema:
+                properties:
+                  conditionConceptSet:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConceptIdArray"
+                    description: >-
+                      conceptset of conditions. Must be an array of concept ids and
+                      use only OMOP standard concepts
+                  nControls:
+                    type: number
+                    description: number of control concepts to suggest
+      responses:
+        default:
+          description: Negative controls ingredient concepts array.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConceptArray'

--- a/inst/sql/sql_server/getConditionEvidenceSummary.sql
+++ b/inst/sql/sql_server/getConditionEvidenceSummary.sql
@@ -1,4 +1,7 @@
-SELECT ims.ingredient_concept_id, c.concept_name, max(ims.evidence_exists) as evidence_exists
+SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} *
+FROM (
+SELECT
+ims.ingredient_concept_id, c.concept_name, max(ims.evidence_exists) as evidence_exists
 FROM (
     -- Where children of the ingredient concept are explicitly included
     SELECT
@@ -13,7 +16,7 @@ FROM (
     UNION
 
     SELECT
-        ms.ingredient_concept_id
+        ms.ingredient_concept_id,
         max(ms.evidence_exists) as evidence_exists
     FROM @cem_schema.matrix_summary ms
     WHERE ms.condition_concept_id IN (@condition_concept_no_desc)
@@ -35,3 +38,4 @@ FROM (
 ) ims
 INNER JOIN @vocabulary.concept c ON (c.concept_id = ims.ingredient_concept_id)
 GROUP BY ims.ingredient_concept_id, c.concept_name
+) results;

--- a/inst/sql/sql_server/getConditionRelationships.sql
+++ b/inst/sql/sql_server/getConditionRelationships.sql
@@ -33,7 +33,10 @@ WITH evidence_summary as (
     }
 )
 
-SELECT DISTINCT
+SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} *
+FROM (
+SELECT
+DISTINCT
     c1.concept_name as concept_name_1,
     c2.concept_name as concept_name_2,
     cu.*
@@ -43,3 +46,4 @@ INNER JOIN @vocabulary.concept c1 ON (c1.concept_id = cu.concept_id_1)
 INNER JOIN @vocabulary.concept c2 ON (c2.concept_id = cu.concept_id_2)
 INNER JOIN @vocabulary.concept_ancestor ca2 ON c2.concept_id = ca2.descendant_concept_id
 INNER JOIN evidence_summary es ON (cu.concept_id_2 = es.condition_concept_id AND cu.concept_id_1 = es.ingredient_concept_id)
+) results;

--- a/inst/sql/sql_server/getIngredientEvidenceSummary.sql
+++ b/inst/sql/sql_server/getIngredientEvidenceSummary.sql
@@ -1,5 +1,7 @@
-SELECT ims.condition_concept_id, c.concept_name, max(ims.evidence_exists) as evidence_exists
-
+SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} *
+FROM (
+SELECT
+ims.condition_concept_id, c.concept_name, max(ims.evidence_exists) as evidence_exists
 FROM (
     -- Where children of the ingredient concept are explicitly included
     {@condition_concept_desc != ''} ? {
@@ -22,3 +24,4 @@ FROM (
 ) ims
 INNER JOIN @vocabulary.concept c ON (c.concept_id = ims.condition_concept_id)
 GROUP BY ims.condition_concept_id, c.concept_name
+) results;

--- a/inst/sql/sql_server/getIngredientRelationships.sql
+++ b/inst/sql/sql_server/getIngredientRelationships.sql
@@ -22,6 +22,8 @@ WITH evidence_summary as (
     }
 )
 
+SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} *
+FROM (
 SELECT DISTINCT
     c1.concept_name as concept_name_1,
     c2.concept_name as concept_name_2,
@@ -32,3 +34,4 @@ INNER JOIN @vocabulary.concept c1 ON (c1.concept_id = cu.concept_id_1)
 INNER JOIN @vocabulary.concept c2 ON (c2.concept_id = cu.concept_id_2)
 INNER JOIN @vocabulary.concept_ancestor ca2 ON c2.concept_id = ca2.descendant_concept_id
 INNER JOIN evidence_summary es ON (cu.concept_id_2 = es.condition_concept_id AND cu.concept_id_1 = es.ingredient_concept_id)
+) results;

--- a/inst/sql/sql_server/getRankedNcExposures.sql
+++ b/inst/sql/sql_server/getRankedNcExposures.sql
@@ -16,7 +16,7 @@ with ingredient_concept_evidence as (
     UNION
 
     SELECT
-        ms.ingredient_concept_id
+        ms.ingredient_concept_id,
         max(ms.evidence_exists) as evidence_exists
     FROM @cem_schema.matrix_summary ms
     WHERE ms.condition_concept_id IN (@condition_concept_no_desc)
@@ -41,6 +41,8 @@ with ingredient_concept_evidence as (
 
 -- We need the set of allowed concepts for the entire concept set
 
+SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} *
+FROM (
 SELECT TOP @n_controls
     iq.drug_concept_id as concept_id,
     c.concept_name
@@ -70,4 +72,5 @@ FROM (
 INNER JOIN ingredient_concept_evidence ies ON (iq.drug_concept_id = ies.ingredient_concept_id AND ies.evidence_exists = 0)
 INNER JOIN @vocabulary.concept c ON c.concept_id = iq.drug_concept_id
 GROUP BY iq.drug_concept_id, c.concept_name
-ORDER BY min(iq.sort_order) ASC;
+ORDER BY min(iq.sort_order) ASC
+) results;

--- a/inst/sql/sql_server/getRankedNcOutcomes.sql
+++ b/inst/sql/sql_server/getRankedNcOutcomes.sql
@@ -2,6 +2,8 @@
 
 -- We need the set of allowed concepts for the entire concept set
 
+SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} *
+FROM (
 SELECT TOP @n_controls
     iq.condition_concept_id as concept_id,
     c.concept_name
@@ -47,4 +49,5 @@ INNER JOIN (
 ) ies ON (iq.condition_concept_id = ies.condition_concept_id AND ies.evidence_exists = 0)
 INNER JOIN @vocabulary.concept c ON c.concept_id = iq.condition_concept_id
 GROUP BY iq.condition_concept_id, c.concept_name
-ORDER BY min(iq.sort_order) ASC;
+ORDER BY min(iq.sort_order) ASC
+) results;

--- a/inst/sql/sql_server/getRelationships.sql
+++ b/inst/sql/sql_server/getRelationships.sql
@@ -1,3 +1,6 @@
+select 
+{@limit_row_count != ''} ? {TOP @limit_row_count} * 
+FROM (
 
 {@ingredient_concepts_desc != '' & @condition_concepts_desc != ''} ? {
 -- BOTH USE DESCENDANTS
@@ -79,3 +82,5 @@ INNER JOIN @vocabulary.concept_ancestor ca2 ON c2.concept_id = ca2.descendant_co
 WHERE ca2.ancestor_concept_id IN (@ingredient_concepts_desc)
 AND cu.concept_id_2  IN (@condition_concepts_no_desc)
 }
+
+) results;

--- a/tests/testthat/test-DatabaseConnectons.R
+++ b/tests/testthat/test-DatabaseConnectons.R
@@ -11,17 +11,17 @@ genericTests <- function(connClass, classes, connectionClass) {
   expect_true(conn$isActive)
   expect_true(DBI::dbIsValid(dbObj = conn$con))
 
-  data <- conn$queryDb("SELECT count(*) AS cnt_test FROM main.person")
+  data <- conn$queryDb("SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} * FROM (SELECT count(*) AS cnt_test FROM main.person) results;")
 
   expect_data_frame(data)
   expect_equal(data$cntTest, 2694)
 
-  data2 <- conn$queryDb("SELECT count(*) AS cnt_test FROM main.person", snakeCaseToCamelCase = FALSE)
+  data2 <- conn$queryDb("SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} * FROM (SELECT count(*) AS cnt_test FROM main.person) results;", snakeCaseToCamelCase = FALSE)
 
   expect_data_frame(data2)
   expect_equal(data2$CNT_TEST, 2694)
 
-  expect_error(conn$queryDb("SELECT 1 * WHERE;"))
+  expect_error(conn$queryDb("SELECT {@limit_row_count != ''} ? {TOP @limit_row_count} * FROM (SELECT 1 * WHERE);"))
 
   conn$closeConnection()
   expect_false(conn$isActive)
@@ -41,3 +41,4 @@ test_that("Database Connector Class works", {
 test_that("Pooled connector Class works", {
   genericTests(PooledConnectionHandler, c("PooledConnectionHandler", "ConnectionHandler"), "Pool")
 })
+


### PR DESCRIPTION
1. Speed up the Docker build by installing the R package dependencies in an earlier step before deploying the CemConnector package (which can be cached for subsequent builds).
2. Add a custom OpenAPI specification yaml file to incorporate a schema for the requests and responses.  Without a schema the __docs__ interactive OpenAPI/Swagger page feature just has blank request fields and the user can't tell what the input JSON format should be. Unfortunately Plumber does not support OpenAPI schemas in the spec it generates so a custom schema is needed. The OpenAPI custom schema yaml file can be maintained here - https://editor.swagger.io/#/
3. Add an optional LIMIT_ROW_COUNT environment variable to limit the number of rows returned from each SQL call to the database. If the LIMIT_ROW_COUNT is undefined then there is no limit.
4. Log the SQL statement if a SQL query fails.